### PR TITLE
Backports fix to #23092 to Rails 5.0

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Reset a new session directly after its creation in ActionDispatch::IntegrationTest#open_session
+
+    Fixes Issue #22742
+
+    *Tawan Sierek*
+
 ## Rails 5.0.7 (March 29, 2018) ##
 
 *   Remove deprecation on `ActionController::Parameters#to_hash` when the instance is

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -457,6 +457,7 @@ module ActionDispatch
       # simultaneously.
       def open_session
         dup.tap do |session|
+          session.reset!
           yield session if block_given?
         end
       end

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -595,6 +595,14 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "creation of multiple integration sessions" do
+    integration_session # initialize first session
+    a = open_session
+    b = open_session
+
+    assert_not_same(a.integration_session, b.integration_session)
+  end
+
   def test_get_with_query_string
     with_test_route_set do
       get '/get_with_params?foo=bar'


### PR DESCRIPTION
### Summary

https://github.com/rails/rails/pull/23093
The issue was fixed in Rails 5.1 and backported to Rails 4.2,
however it was not backported to Rails 5.0 and is causing our tests to
fail.
